### PR TITLE
fix: restore the `types` field in the `package.json` file

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 			}
 		}
 	},
+	"types": "./dist/index.d.cts",
 	"files": [
 		"./dist/"
 	],


### PR DESCRIPTION
TypeScript may not use the `"types"` import condition.

For example, if the value of the `moduleResolution` option is `"node"`. In this case, TypeScript uses the `types` field and the `"types"` import condition is not used.

So even if the `"types"` import condition is used, `package.json` still needs the `types` field for fallback. Therefore, I have restored the `types` field that was removed in f7240436632735fdab258c5fc8e1456c9e2a0db1.

Resolves #26

- [x] I tested this change

    ```console
    $ pnpm run build && pnpm pack
    $
    $ mkdir test-pr-28 && cd test-pr-28
    $
    $ echo '{}' > ./package.json
    $ echo '{ "compilerOptions": { "moduleResolution": "node", "esModuleInterop": true, "strict": true } }' > ./tsconfig.node.json
    $ echo '{ "compilerOptions": { "moduleResolution": "node16", "esModuleInterop": true, "strict": true } }' > ./tsconfig.node16.json
    $
    $ echo 'console.log(require("used-pm")())' > foo.cjs
    $ echo 'import currentPackageManager from "used-pm"; console.log(currentPackageManager())' > foo.mjs
    $ cp foo.mjs foo.cts
    $ cp foo.mjs foo.mts
    $
    $ npm i typescript ../used-pm-1.0.2.tgz # I am using the npm command by intention. When using pnpm, used-pm 1.0.2 released to npm may be added instead of used-pm-1.0.2.tgz due to global caching
    $
    $ pnpm exec node foo.cjs && pnpm exec node foo.mjs && pnpm exec tsc -p tsconfig.node16.json --noEmit && pnpm exec tsc -p tsconfig.node.json --noEmit
    ```
